### PR TITLE
Remove ContentElement::addTyposcriptConstants()

### DIFF
--- a/Classes/ContentElement.php
+++ b/Classes/ContentElement.php
@@ -2,23 +2,23 @@
 namespace AppZap\FluidContentelements;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ContentElement {
+
+	/**
+	 * @var array
+	 */
+	static private $registeredExtensions = array();
 
 	/**
 	 * Use in ext_localconf.php
 	 *
 	 * @param string $extensionKey
+	 * @deprecated Not necessary anymore. Has been integrated in registerContentElement()
 	 */
 	public static function addTyposcriptConstants($extensionKey) {
-		$constants = trim('
-			plugin.' . self::getPluginNamespace($extensionKey) . '.view {
-				templateRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/
-				partialRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/Partials/
-				layoutRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/Layouts/
-			}
-		');
-		ExtensionManagementUtility::addTypoScript($extensionKey, 'constants', $constants);
+		GeneralUtility::logDeprecatedFunction();
 	}
 
 	/**
@@ -29,6 +29,18 @@ class ContentElement {
 	 * @param bool $standardHeader
 	 */
 	public static function addContentElementTyposcript($extensionKey, $title, $standardHeader = TRUE) {
+		if (!isset(static::$registeredExtensions[$extensionKey])) {
+			$constants = trim('
+				plugin.' . self::getPluginNamespace($extensionKey) . '.view {
+					templateRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/
+					partialRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/Partials/
+					layoutRootPath = EXT:' . $extensionKey . '/Resources/Private/ContentElements/Layouts/
+				}
+			');
+			ExtensionManagementUtility::addTypoScript($extensionKey, 'constants', $constants);
+			static::$registeredExtensions[$extensionKey] = NULL;
+		}
+
 		$filename = str_replace(' ', '', $title);
 		$typename = self::getPluginNamespace($extensionKey) . '_' . strtolower(str_replace(' ', '_', $title));
 		// Frontend

--- a/Classes/ContentElement.php
+++ b/Classes/ContentElement.php
@@ -38,7 +38,7 @@ class ContentElement {
 				}
 			');
 			ExtensionManagementUtility::addTypoScript($extensionKey, 'constants', $constants);
-			static::$registeredExtensions[$extensionKey] = NULL;
+			static::$registeredExtensions[$extensionKey] = TRUE;
 		}
 
 		$filename = str_replace(' ', '', $title);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ But until then I'll stick with this handy little extension that let's you create
 In your `ext_localconf.php`:
 
 ```php
-\AppZap\FluidContentelements\ContentElement::addTyposcriptConstants($_EXTKEY);
 \AppZap\FluidContentelements\ContentElement::addContentElementTyposcript($_EXTKEY, 'My New Element');
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your `ext_localconf.php`:
 In your `ext_tables.php`:
 
 ```php
-\AppZap\FluidContentelements\ContentElement::registerContentElement($_EXTKEY, 'My New Element`);
+\AppZap\FluidContentelements\ContentElement::registerContentElement($_EXTKEY, 'My New Element');
 ```
 
 In your TYPO3 extension create the following file `Resources/Private/ContentElements/MyNewElement.html` to render your content element. (The file name is the name of the element without spaces).


### PR DESCRIPTION
Convenience over Configuration:
Require one less API call by moving the logic of
ContentElement::addTyposcriptConstants()
to ContentElement::addContentElementTyposcript()
